### PR TITLE
update to latest flumeview-level to fix reindex bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "explain-error": "^1.0.1",
-    "flumeview-level": "^1.0.3",
+    "flumeview-level": "^2.0.5",
     "map-filter-reduce": "^3.0.2",
     "pull-flatmap": "0.0.1",
     "pull-paramap": "^1.1.3",


### PR DESCRIPTION
`flumeview-query` is still using an ancient old version of `flumeview-level` (`1.0.3`) that doesn't reindex when the since value changes. Instead it throws an error.

This PR bumps to version `2.0.5`. Haven't tested this in `flumeview-query` but it worked fine in my `links.js` fork inside of `ssb-backlinks`.

ssbc/scuttlebot#427