### PR TITLE
Add includeOriginalMessageValue option needed for ssb-backlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function (version, opts) {
     view.explain = function (opts) {
 
       opts = opts || {}
-      var _opts = {}
       var q, k
 
       if(isArray(opts.query)) {

--- a/links.js
+++ b/links.js
@@ -50,7 +50,6 @@ module.exports = function (indexes, links, version) {
     index.read = function (opts) {
 
       opts = opts || {}
-      var _opts = {}
       var q, k
 
       if(isArray(opts.query)) {
@@ -77,6 +76,7 @@ module.exports = function (indexes, links, version) {
             return emit
           })
         )
+
       var _opts = query(index, q)
 
       _opts.values = true
@@ -86,13 +86,13 @@ module.exports = function (indexes, links, version) {
       _opts.live = opts.live
       _opts.old = opts.old
       _opts.sync = opts.sync
-      _opts.includeOriginalMessageValue = opts.includeOriginalMessageValue
+      _opts.unlinkedValues = opts.unlinkedValues
 
       return pull(
         read(_opts),
         pull.map(function (data) {
           if(data.sync) return data
-          var o = opts.includeOriginalMessageValue ? data.value : {}
+          var o = opts.unlinkedValues ? data.value : {}
           for(var i = 0; i < index.value.length; i++)
             u.set(index.value[i], data.key[i+1], o)
           return o

--- a/links.js
+++ b/links.js
@@ -86,12 +86,13 @@ module.exports = function (indexes, links, version) {
       _opts.live = opts.live
       _opts.old = opts.old
       _opts.sync = opts.sync
+      _opts.includeOriginalMessageValue = opts.includeOriginalMessageValue
 
       return pull(
         read(_opts),
         pull.map(function (data) {
           if(data.sync) return data
-          var o = {}
+          var o = opts.includeOriginalMessageValue ? data.value : {}
           for(var i = 0; i < index.value.length; i++)
             u.set(index.value[i], data.key[i+1], o)
           return o


### PR DESCRIPTION
I was comparing the forks used in both ssb-private and ssb-backlinks. ssb-private works with vanilla now, but ssb-backlinks need this patch.

This is another thing that was in the fork that I don't think is need anymore:

      // HACK: allow manual selection of indexes
      if (opts.index) {
        index = indexes.find(x => x.key === opts.index)
      }

An option you can pass to force the query to use a specific index. While this might be fine on its own, the original problem was: https://github.com/ssbc/patchwork/issues/556. And we now have explain so I would rather we find out why the index selection didn't work and if we can fix it to use the correct index. There might be changes since that actually makes it pick the right index now.

This should close #6