### PR TITLE
should pass `old` to fallback query when no index selected

### DIFF
--- a/links.js
+++ b/links.js
@@ -66,7 +66,7 @@ module.exports = function (indexes, links, version) {
       if(!index)
         return pull(
           log.stream({
-            values: true, seqs: false, live: opts.live, limit: opts.limit, reverse: opts.reverse
+            values: true, seqs: false, live: opts.live, old: opts.old, limit: opts.limit, reverse: opts.reverse
           }),
           Flatmap(function (data) {
             var emit = []


### PR DESCRIPTION
If you call `index.read({old: false})`, right now it actually just returns the entire database, rather than just that latest.

This PR fixes this by adding `old` to the list of `opts` that are passed to the log stream.

---

By the way @arj03, this bug in combination with removing the ability to select indexes in `ssb-backlinks` has [broken live backlinks](https://github.com/ssbc/patchwork/pull/789#issuecomment-386484329) in Patchwork. I think we should either add the ability to choose an index into `flumeview-query` or go back to a fork in `ssb-backlinks`. I'll create a second PR for this.