### PR TITLE
add option to force select index on Query and Links

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,13 @@ var FlumeViewLevel = require('flumeview-level')
 var isArray = Array.isArray
 var isNumber = function (n) { return 'number' === typeof n }
 var isObject = function (o) { return o && 'object' === typeof o && !isArray(o) }
-
+var findByKey = function (indexes, key) {
+  for (var i = 0; i < indexes.length; i++) {
+    if (indexes[i] && indexes[i].key === key) {
+      return indexes[i]
+    }
+  }
+}
 
 //sorted index.
 
@@ -60,7 +66,10 @@ module.exports = function (version, opts) {
       else
         q = {}
 
-      var index = select(indexes, q)
+      var index = opts.index
+        ? findByKey(indexes, opts.index)
+        : select(indexes, q)
+        
       if(!index) return {scan: true}
       var _opts = query(index, q, exact)
       _opts.values = true
@@ -94,5 +103,3 @@ module.exports = function (version, opts) {
     return view
   }
 }
-
-

--- a/links.js
+++ b/links.js
@@ -10,6 +10,13 @@ var Flatmap = require('pull-flatmap')
 var FlumeViewLevel = require('flumeview-level')
 
 var isArray = Array.isArray
+var findByKey = function (indexes, key) {
+  for (var i = 0; i < indexes.length; i++) {
+    if (indexes[i] && indexes[i].key === key) {
+      return indexes[i]
+    }
+  }
+}
 
 //sorted index.
 
@@ -61,7 +68,9 @@ module.exports = function (indexes, links, version) {
       else
         q = {}
 
-      var index = select(indexes, q)
+      var index = opts.index 
+        ? findByKey(indexes, opts.index)
+        : select(indexes, q)
 
       if(!index)
         return pull(
@@ -104,5 +113,3 @@ module.exports = function (indexes, links, version) {
     return index
   }
 }
-
-

--- a/test/links.js
+++ b/test/links.js
@@ -93,6 +93,23 @@ tape('simple', function (t) {
 
   })
 
+  t.test('specify index', function (t) {
+    all(links.read({index: 'DRS'}), function (err, ary) {
+      if(err) throw err
+      t.deepEqual(ary, [ 
+        { rel: 'end', dest: 'END', source: 'READY' },
+        { rel: 'end', dest: 'END', source: 'START' },
+        { rel: 'error', dest: 'END', source: 'END' },
+        { rel: 'error', dest: 'ERROR', source: 'READY' },
+        { rel: 'error', dest: 'ERROR', source: 'START' },
+        { rel: 'read', dest: 'READY', source: 'START' },
+        { rel: 'read', dest: 'START', source: 'READY' } 
+      ])
+      t.end()
+    })
+
+  })
+
   t.test('live', function (t) {
     t.deepEqual(live, raw.filter(function (e) { return e.rel[0] == 'e' }))
 //[{


### PR DESCRIPTION
There are a few cases when you just want to read the index without filtering it (for example, in patchwork I stream a list of all changes to backlinks for updating a shared backlinks cache). 

But if you try to do a `read` without a filter right now, it will stream the entire database. You also have no control over the order of the results. There is no (good) reason I can think of for ever wanting to stream the entire database using an index. There should be a way to just read items that are in that index.

**This PR adds an additional `index` option to both `Query` and `Links` on their `.read` methods. It allows you to specify the name of the index you want to use to retrieve your results.**

So obviously, this is not a very magical or ideal solution, but I've found it very helpful in patchwork with the backlinks index. It was one of the main reasons that I [originally forked](https://github.com/ssbc/ssb-backlinks/issues/4) in the first place. Happy for other ideas, but for now gonna use this fork in Patchwork.

@dominictarr @arj03 

See also #11 